### PR TITLE
Different sounds for idle_prompt vs Stop events

### DIFF
--- a/sounds/README.md
+++ b/sounds/README.md
@@ -6,13 +6,32 @@ This directory contains Starcraft character voice lines organized by character.
 
 ```
 sounds/
-├── marine/          # Terran Marine voice lines
-├── zealot/          # Protoss Zealot voice lines
-├── battlecruiser/   # Terran Battlecruiser voice lines
-├── hydralisk/       # Zerg Hydralisk sounds
-├── carrier/         # Protoss Carrier voice lines
+├── marine/
+│   ├── idle/         # Played on idle_prompt (waiting for input)
+│   │   └── yes_sir.wav
+│   ├── complete/     # Played on Stop (task finished)
+│   │   └── job_done.wav
+│   └── ready.wav     # Fallback (played if no event-specific sounds)
+├── zealot/
+│   ├── idle/
+│   ├── complete/
+│   └── (fallback sounds)
+├── battlecruiser/
+├── hydralisk/
+├── carrier/
 └── (add more characters as needed)
 ```
+
+### Event-Specific Sounds
+
+For contextually appropriate audio, organize sounds into subdirectories:
+
+| Event | Directory | Example Lines |
+|-------|-----------|---------------|
+| `idle_prompt` | `{character}/idle/` | "Yes sir?", "What do you need?", questioning sounds |
+| `Stop` | `{character}/complete/` | "Job's done!", "Ready!", confirmation sounds |
+
+**Fallback behavior**: If no event-specific subdirectory exists, sounds from the root character directory are used. This maintains backwards compatibility.
 
 ## Adding Sounds
 


### PR DESCRIPTION
Closes #6

## Summary
Play contextually appropriate sounds based on the hook event type.

## Changes
- Modified `claude-overlord.sh` to:
  - Extract `hook_event_name` from JSON input
  - Map events to sound categories: `Notification` → `idle/`, `Stop` → `complete/`
  - Look in event-specific subdirectory first (e.g., `sounds/marine/idle/`)
  - Fall back to root character directory for backwards compatibility

- Updated `sounds/README.md` with new directory structure

## Directory Structure
```
sounds/marine/
├── idle/           # Played on idle_prompt
│   └── yes_sir.wav
├── complete/       # Played on Stop  
│   └── job_done.wav
└── ready.wav       # Fallback
```

## Example Sounds
| Event | Directory | Example Lines |
|-------|-----------|---------------|
| `idle_prompt` | `idle/` | "Yes sir?", "What do you need?" |
| `Stop` | `complete/` | "Job's done!", "Ready!" |

🤖 Generated with [Claude Code](https://claude.com/claude-code)