### PR TITLE
Add playback logging to claude-overlord.sh

### DIFF
--- a/claude-overlord.sh
+++ b/claude-overlord.sh
@@ -78,4 +78,11 @@ sound_file="${sounds[$sound_index]}"
 # Play sound (non-blocking via &, afplay is macOS native)
 afplay "$sound_file" &
 
+# Log playback for debugging and clip analysis
+LOG_FILE="${CLAUDE_OVERLORD_LOG:-$HOME/.claude/claude-overlord/playback.log}"
+LOG_DIR=$(dirname "$LOG_FILE")
+if [ -d "$LOG_DIR" ]; then
+  echo "$(date -u +"%Y-%m-%dT%H:%M:%SZ") $character $(basename "$sound_file")" >> "$LOG_FILE"
+fi
+
 exit 0

--- a/tests/claude-overlord.bats
+++ b/tests/claude-overlord.bats
@@ -151,3 +151,25 @@ teardown() {
     run bash -c 'echo "" | "$PROJECT_ROOT/claude-overlord.sh"'
     [ "$status" -eq 0 ]
 }
+
+# --- Playback Logging ---
+# Log each clip played for debugging and clip analysis.
+
+@test "logs playback when log directory exists" {
+    create_mock_sounds
+    mkdir -p "$TEST_HOME/.claude/claude-overlord"
+    export CLAUDE_OVERLORD_LOG="$TEST_HOME/.claude/claude-overlord/playback.log"
+    run bash -c 'echo "{\"session_id\":\"test\"}" | "$PROJECT_ROOT/claude-overlord.sh"'
+    [ "$status" -eq 0 ]
+    [ -f "$CLAUDE_OVERLORD_LOG" ]
+    # Log should contain character name and clip filename
+    grep -q "marine" "$CLAUDE_OVERLORD_LOG" || grep -q "zealot" "$CLAUDE_OVERLORD_LOG" || grep -q "zergling" "$CLAUDE_OVERLORD_LOG"
+}
+
+@test "skips logging when log directory does not exist" {
+    create_mock_sounds
+    export CLAUDE_OVERLORD_LOG="$TEST_HOME/nonexistent/playback.log"
+    run bash -c 'echo "{\"session_id\":\"test\"}" | "$PROJECT_ROOT/claude-overlord.sh"'
+    [ "$status" -eq 0 ]
+    [ ! -f "$CLAUDE_OVERLORD_LOG" ]
+}


### PR DESCRIPTION
Closes #21

## Summary
Adds logging of each clip played to `~/.claude/claude-overlord/playback.log` for debugging and clip analysis.

Log format: `2026-01-11T23:32:35Z marine clip_007.wav`

## Changes
- Add logging after `afplay` call with timestamp, character, and filename
- Support `CLAUDE_OVERLORD_LOG` env var to override log path
- Add tests for logging behavior (success and graceful degradation)

## Context
Part of the "fix clips after the fact" approach - when a clip sounds wrong, you can check the log to identify which file played.

🤖 Generated with [Claude Code](https://claude.com/claude-code)