### PR TITLE
Add watch.sh documentation to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,3 +33,21 @@ cd claude-overlord
 - Battlecruiser
 - Carrier
 - And more...
+
+## Live Monitoring
+
+Run `./watch.sh` to see a colorized, real-time view of hook events:
+
+```
+Claude Overlord - Live Hook Monitor
+====================================
+
+Recent history:
+12:34:56 [abc123] Stop    marine       ready.wav
+
+--- Live ---
+
+12:35:02 [xyz789] Notify  zealot       my-life-for-aiur.wav
+```
+
+Each session gets a consistent color based on its ID, making it easy to track multiple Claude sessions at once.


### PR DESCRIPTION
## Summary
- Documents the live hook monitoring feature (`./watch.sh`) in the main README
- Includes example output showing colorized session tracking

This makes it easier for users to discover this useful debugging tool.

🤖 Generated with [Claude Code](https://claude.com/claude-code)